### PR TITLE
Add `/user` endpoint

### DIFF
--- a/pages/api/v1/user/index.js
+++ b/pages/api/v1/user/index.js
@@ -20,5 +20,10 @@ async function getHandler(request, response) {
 
   const userFound = await user.findOneById(sessionObject.user_id);
 
+  response.setHeader(
+    "Cache-Control",
+    "no-store, no-cache, max-age=0, must-revalidate",
+  );
+
   return response.status(200).json(userFound);
 }

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -30,6 +30,12 @@ describe("GET /api/v1/user", () => {
 
       expect(response.status).toBe(200);
 
+      const cacheControl = response.headers.get("Cache-Control");
+
+      expect(cacheControl).toBe(
+        "no-store, no-cache, max-age=0, must-revalidate",
+      );
+
       const responseBody = await response.json();
 
       expect(responseBody).toEqual({
@@ -92,6 +98,74 @@ describe("GET /api/v1/user", () => {
         message: "Verifique se este usuário está logado e tente novamente.",
         action: "Usuário não possui sessão ativa.",
         status_code: 401,
+      });
+    });
+
+    test("With halfway-expired session", async () => {
+      jest.useFakeTimers({
+        now: new Date(Date.now() - session.EXPIRATION_IN_MILLISECONDS / 2),
+      });
+
+      const createdUser = await orchestrator.createUser({
+        name: "Maria",
+        last_name: "Doe",
+        email: "maria.doe@gmail.com",
+        password: "senha123",
+        campus: 2,
+      });
+
+      const sessionObject = await orchestrator.createSession(createdUser.id);
+
+      jest.useRealTimers();
+
+      const response = await fetch("http://localhost:3000/api/v1/user", {
+        headers: {
+          cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: createdUser.id,
+        name: "Maria",
+        last_name: "Doe",
+        campus: 2,
+        email: createdUser.email,
+        password: createdUser.password,
+        created_at: createdUser.created_at.toISOString(),
+        updated_at: createdUser.updated_at.toISOString(),
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+
+      // Session renewal assertions
+      const renewedSessionObject = await session.findOneValidByToken(
+        sessionObject.token,
+      );
+
+      expect(
+        renewedSessionObject.expires_at > sessionObject.expires_at,
+      ).toEqual(true);
+      expect(
+        renewedSessionObject.updated_at > sessionObject.updated_at,
+      ).toEqual(true);
+
+      // Set‑Cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: sessionObject.token,
+        maxAge: session.EXPIRATION_IN_MILLISECONDS / 1000,
+        path: "/",
+        httpOnly: true,
       });
     });
 


### PR DESCRIPTION
### Description
This pull request adds the following:
- endpoint `/user` to return user info;
- renew user session expiration;
- avoid cache-control;